### PR TITLE
fix: date not working on macos

### DIFF
--- a/fork.sh
+++ b/fork.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# Get ISO 8601 datetime with seconds with support for BSD date (MacOS)
+iso_datetime() {
+  date -Iseconds 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S%z"
+}
+
 # Check arguments
 if [ "$#" -ne 1 ] && [ "$#" -ne 2 ]; then
     echo "Usage: $0 <new_agent_workspace> [<new_agent_name>]"
@@ -103,7 +108,7 @@ copy_file TASKS.md
 # Initial setup task from template
 copy_file tasks/templates/initial-agent-setup.md
 cp "${SOURCE_DIR}/tasks/templates/initial-agent-setup.md" "${TARGET_DIR}/tasks/"
-./scripts/tasks.py edit initial-agent-setup --set created $(date --iso-8601=second)
+./scripts/tasks.py edit initial-agent-setup --set created $(iso_datetime)
 
 # Create projects README
 cat > "${TARGET_DIR}/projects/README.md" << EOL


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `iso_datetime()` function in `fork.sh` to support ISO 8601 datetime formatting on MacOS.
> 
>   - **Behavior**:
>     - Adds `iso_datetime()` function in `fork.sh` to get ISO 8601 datetime with seconds, supporting both GNU and BSD `date` (MacOS).
>     - Replaces `date --iso-8601=second` with `iso_datetime()` in `fork.sh` for setting creation date in `tasks.py` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-agent-template&utm_source=github&utm_medium=referral)<sup> for da34ca15a5e7f155501e082e9997ee9621731dfa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->