### PR TITLE
docs: link native gptme service init CLI for headless agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,6 @@ gptme-agent stop                # Pause scheduled runs
 
 See the [gptme agents documentation](https://gptme.org/docs/agents.html) for service installation and management commands.
 
-**Alternative — native `gptme service init`**: If you prefer to scaffold a bare headless agent yourself (systemd unit + startup script + skeleton `gptme.toml`/`AGENTS.md`) instead of forking this template, recent gptme builds ship a built-in CLI:
-
-```sh
-gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
-```
-
-This generates a systemd user service (with optional timer) that runs the agent headlessly — the same pattern a reference agent uses to run hundreds of autonomous sessions/day. Run `gptme service init --help` for all options. It's a great complement to this template: fork the template for a full workspace, or `service init` for a minimal one.
-
 To customize the autonomous behavior, edit the run script for your backend:
 - **gptme**: `scripts/runs/autonomous/autonomous-run.sh`
 - **Claude Code**: `scripts/runs/autonomous/autonomous-run-cc.sh`
@@ -164,6 +156,16 @@ To customize the autonomous behavior, edit the run script for your backend:
 - Safety guardrails (GREEN/YELLOW/RED operation classification)
 - Session documentation and state management
 - **Multi-backend**: Supports both gptme and Claude Code backends
+
+### Minimal Headless Alternative
+
+If you don't need the full template workspace, gptme ships a built-in CLI to scaffold a bare headless agent (systemd user service + startup script + skeleton `gptme.toml`/`AGENTS.md`):
+
+```sh
+gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
+```
+
+Run `gptme service init --help` for all options. Fork this template for a full agent workspace; use `gptme service init` for a minimal one.
 <!--/autonomous-->
 
 <!--template-->

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ gptme-agent stop                # Pause scheduled runs
 
 See the [gptme agents documentation](https://gptme.org/docs/agents.html) for service installation and management commands.
 
+**Alternative — native `gptme service init`**: If you prefer to scaffold a bare headless agent yourself (systemd unit + startup script + skeleton `gptme.toml`/`AGENTS.md`) instead of forking this template, recent gptme builds ship a built-in CLI:
+
+```sh
+gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
+```
+
+This generates a systemd user service (with optional timer) that runs the agent headlessly — the same pattern a reference agent uses to run hundreds of autonomous sessions/day. Run `gptme service init --help` for all options. It's a great complement to this template: fork the template for a full workspace, or `service init` for a minimal one.
+
 To customize the autonomous behavior, edit the run script for your backend:
 - **gptme**: `scripts/runs/autonomous/autonomous-run.sh`
 - **Claude Code**: `scripts/runs/autonomous/autonomous-run-cc.sh`


### PR DESCRIPTION
Links the new `gptme service init` CLI (shipped in gptme/gptme#3574) from the template's Autonomous Operation section.

The template already documents `gptme-agent install` for running this template headlessly. This PR adds a short pointer to the native alternative — scaffolding a bare headless agent with `gptme service init --name myagent --model ... --work-dir ...` — so users who don't need the full template workspace still discover the one-command headless path.

Refs gptme/gptme#3574 (headless-agent demand).