### PR TITLE
docs(tasks): document gptodo ready --skip-claimed for concurrent sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ echo "entry" >> journal/2025-10-14/topic.md
 ### Tasks
 
 - Managed via files in `tasks/` with YAML frontmatter
-- CLI: `gptodo status|show|edit`
+- CLI: `gptodo status|ready|show|edit`
+- Select work with `gptodo ready --skip-claimed` (not `gptodo status` — status includes blocked/waiting tasks)
 - Assess complexity by scope, not time
 - Mark done when core functionality works
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -24,10 +24,15 @@ uv tool install git+https://github.com/gptme/gptme-contrib#subdirectory=packages
 **Commands**:
 
 ```sh
-# View task status
+# View task status (overview — includes blocked/waiting tasks)
 gptodo status              # Show all tasks
 gptodo status --compact    # Show only new/active
 gptodo status --type tasks # Show specific type
+
+# Select unblocked work (use this instead of scanning `gptodo status`)
+gptodo ready                         # Unblocked backlog/todo/active
+gptodo ready --state todo --jsonl    # One state, one JSON object per line
+gptodo ready --skip-claimed --jsonl  # Concurrent sessions: hide already-claimed tasks
 
 # List tasks
 gptodo list               # List all tasks
@@ -37,6 +42,16 @@ gptodo list --sort date   # Sort by date
 # Show task details
 gptodo show <task-id>     # Show specific task
 ```
+
+### Selecting work (`gptodo ready`)
+
+`gptodo status` is an overview of everything, including blocked and waiting tasks. Concurrent sessions that pick from status will converge on the same blocked work.
+
+`gptodo ready` is the selector: it lists tasks that are genuinely unblocked (no unresolved `depends`, no `waiting_for` blocker). `--state backlog|todo|active|ready_for_review` narrows the pool; `--jsonl` is the machine-readable form for autonomous runners.
+
+For concurrent sessions, add `--skip-claimed`. It hides tasks already held by another coordination session (`state/coordination/coord.db`, keys like `cascade:task:<id>`). If that DB is absent — a typical fresh fork — the flag degrades silently and you still get the unblocked set.
+
+`--skip-claimed` shipped in [gptme-contrib#1510](https://github.com/gptme/gptme-contrib/pull/1510) (2026-08-25). Re-install gptodo from gptme-contrib if `gptodo ready --help` does not list the flag.
 
 ### Task Metadata Updates
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -5,9 +5,13 @@ Tools available in the workspace for managing tasks, searching, and operating au
 ## Task Management
 
 ```bash
-# View task status
+# View task status (overview — includes blocked/waiting tasks)
 gptodo status              # All tasks
 gptodo status --compact    # Active only
+
+# Select unblocked work (use this instead of scanning status)
+gptodo ready                         # Unblocked backlog/todo/active
+gptodo ready --skip-claimed --jsonl  # Concurrent sessions: hide already-claimed tasks
 
 # View specific task
 gptodo show <task-id>
@@ -111,7 +115,7 @@ python3 ./scripts/migrate-journals.py
 ### Starting a session
 1. Read identity files (ABOUT.md, ARCHITECTURE.md, TASKS.md)
 2. Run `./scripts/context.sh` for dynamic context
-3. Check `gptodo status --compact` for active work
+3. Check `gptodo ready --skip-claimed --jsonl` for unblocked work
 4. Start working
 
 ### Committing changes

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -76,12 +76,14 @@ are handled by dedicated services. Do NOT treat them as a work queue.
 Try these tiers in order until you find actionable work:
 
 ### Tier 1 — Active tasks
-Run `gptodo status --compact`. If a task is `active` or `ready_for_review`,
-inspect it. Skip tasks with `waiting_for` set.
+`gptodo ready --state active --skip-claimed --jsonl` and
+`gptodo ready --state ready_for_review --skip-claimed --jsonl`.
+Inspect a candidate. Skip anything with `waiting_for` still set.
 
 ### Tier 2 — Backlog candidates
-`gptodo ready --state backlog --jsonl`. Prefer small, self-contained work
-completable in one session.
+`gptodo ready --state todo --skip-claimed --jsonl` then
+`gptodo ready --state backlog --skip-claimed --jsonl`.
+Prefer small, self-contained work completable in one session.
 
 ### Tier 3 — Self-improvement work
 If all tasks are blocked, do productive internal work. Pick from this list

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -81,8 +81,7 @@ Try these tiers in order until you find actionable work:
 Inspect a candidate. Skip anything with `waiting_for` still set.
 
 ### Tier 2 — Backlog candidates
-`gptodo ready --state todo --skip-claimed --jsonl`,
-`gptodo ready --state new --skip-claimed --jsonl` (legacy alias for todo), then
+`gptodo ready --state todo --skip-claimed --jsonl`, then
 `gptodo ready --state backlog --skip-claimed --jsonl`.
 Prefer small, self-contained work completable in one session.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -81,7 +81,8 @@ Try these tiers in order until you find actionable work:
 Inspect a candidate. Skip anything with `waiting_for` still set.
 
 ### Tier 2 — Backlog candidates
-`gptodo ready --state todo --skip-claimed --jsonl` then
+`gptodo ready --state todo --skip-claimed --jsonl`,
+`gptodo ready --state new --skip-claimed --jsonl` (legacy alias for todo), then
 `gptodo ready --state backlog --skip-claimed --jsonl`.
 Prefer small, self-contained work completable in one session.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,7 +121,7 @@ $SCRIPT_DIR/context-notifications.sh  # Your custom script
 
 ## Task Management: gptodo (Optional)
 
-**Purpose**: CLI for task management (status, list, edit operations).
+**Purpose**: CLI for task management (status, ready, list, edit operations).
 
 **Installation**:
 ```bash
@@ -130,11 +130,15 @@ uv tool install git+https://github.com/gptme/gptme-contrib#subdirectory=packages
 
 **Common commands**:
 ```bash
-# View task status
+# View task status (overview — includes blocked/waiting tasks)
 gptodo status
 
 # Compact view (for context)
 gptodo status --compact
+
+# Select unblocked work (use this instead of scanning status)
+gptodo ready
+gptodo ready --skip-claimed --jsonl
 
 # List all tasks
 gptodo list


### PR DESCRIPTION
`gptodo status` shows every task, including blocked and waiting ones. Concurrent sessions that pick from it converge on the same work. The selector that already exists — and now filters coordination claims — is `gptodo ready --skip-claimed` (gptme/gptme-contrib#1510).

This PR documents that in the surfaces forks actually read at session start:

- `TASKS.md` — commands plus a short "Selecting work" section
- `WORKFLOW.md` — Tier 1/2 pick `gptodo ready --skip-claimed --jsonl` instead of `gptodo status --compact`
- `AGENTS.md` / `TOOLS.md` / `scripts/README.md` — matching cheat-sheet lines so the docs don't contradict each other

`--skip-claimed` degrades silently when `state/coordination/coord.db` is absent, so a fresh fork without a coordination layer still gets the unblocked set.

The template's gptme-contrib submodule pin predates #1510. The install command in `TASKS.md` already pulls gptodo from GitHub, so forks that follow it get the flag; `TASKS.md` also says to re-install if `gptodo ready --help` does not list it. Submodule bump is out of scope here.

Forkability remainder of gptme/gptme-contrib#1510 (the wrapper-script plan was replaced by this docs pointer).