### PR TITLE
fix(precommit): scope task frontmatter validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,9 @@ repos:
         entry: ./gptme-contrib/scripts/precommit/validate_task_frontmatter.py
         language: system
         types: [markdown]
-        files: ^tasks/.*\.md$
+        files: ^tasks/(archive/)?[^/]+\.md$
+        exclude: ^tasks/(templates|video-scripts|agent-setup-interview)/
+        pass_filenames: true
       - id: validate-task-metadata
         name: Validate task metadata
         entry: bash -c 'if command -v gptodo &> /dev/null; then gptodo check; else echo "gptodo not installed (optional) - skipping validation"; fi'


### PR DESCRIPTION
## Problem

The generic task-frontmatter validator is already enabled in the agent template, but its broad `tasks/.*\.md` filter also sends nested template and support documents through the runtime task schema. That makes the shared validator noisy for forks and diverges from the proven Bob configuration.

The broader source audit found that only two candidate generic validators currently exist in `gptme-contrib`, and both are already wired here. The other suggested hooks remain Bob-local and are deliberately not copied into the template.

## Change

- limit frontmatter validation to direct task files and one-level archived tasks
- exclude conventional non-task support directories
- make filename passing explicit

## Verification

- `prek run validate-task-frontmatter --files tasks/validator-smoke.<tmp>.md`
- `prek run check-yaml --files .pre-commit-config.yaml`
- commit-time pre-commit suite