### PR TITLE
docs: explain portable multi-harness agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,19 @@ make typecheck   # Type checking
 - `context_cmd` runs `scripts/context.sh` for dynamic context
 - Lessons matched by keywords automatically
 
-### Claude Code / Codex
-- Only this file is auto-loaded — **manually read bootstrap files** listed above
+### Claude Code
+- `CLAUDE.md` points to this file, so these instructions load automatically
+- Autonomous runs use `scripts/build-system-prompt.sh` to load the files listed
+  in `gptme.toml`; interactive runs should read the bootstrap files manually
 - Run `scripts/context.sh` at session start for dynamic context (tasks, GitHub, git status)
-- No automatic lesson injection — check `lessons/` when relevant
+- The generic template does not install automatic lesson-matching hooks
+
+### Codex and Other Runtimes
+- Codex discovers this `AGENTS.md`, but the template ships no Codex autonomous launcher
+- Manually read the bootstrap files and run `scripts/context.sh` at session start
+- No automatic lesson injection is provided; check `lessons/` when relevant
+- Grok Build and Pi are not wired by this template; using them reliably requires
+  an adapter that injects the same identity, context, and task-lifecycle contract
 
 ### Nested Claude Code Subprocesses
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,9 @@ make typecheck   # Type checking
 - Lessons matched by keywords automatically
 
 ### Claude Code
-- `CLAUDE.md` points to this file, so these instructions load automatically
+- `CLAUDE.md` is a git symlink to this file, not a separate copy, so Claude Code
+  loads these same instructions automatically. Do not replace the symlink with
+  a duplicated file.
 - Autonomous runs use `scripts/build-system-prompt.sh` to load the files listed
   in `gptme.toml`; interactive runs should read the bootstrap files manually
 - Run `scripts/context.sh` at session start for dynamic context (tasks, GitHub, git status)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,38 @@ gptme "hello"
 
 The agent's context is automatically loaded via `gptme.toml` which configures the files and context command to include.
 
-### Claude Code Backend
+### One Agent, Multiple Runtimes
+
+**Your agent is the workspace, not the harness.** Identity, memory, tasks,
+lessons, journal, workflow, and audit history live in this version-controlled
+repository. A harness is one runtime that can operate on that durable state.
+
+Keep these layers separate when configuring or comparing an agent:
+
+| Layer | What it owns | Examples |
+|-------|--------------|----------|
+| **Agent workspace** | Identity, memory, tasks, journal, lessons, workflow | This repository |
+| **Harness / runtime** | Agent loop, tools, context loading, permissions | gptme, Claude Code, Codex, Grok Build |
+| **Model / provider** | The model that reasons and generates output | GPT, Claude, Grok, Gemini, DeepSeek, local models |
+| **Access / billing** | How inference is authenticated and paid for | API keys, local inference, managed services, compatible subscriptions |
+
+These layers are orthogonal, but they are not a full Cartesian product: each
+harness supports a different set of models and access methods. The table below
+states exactly what this template ships and where an external adapter is still
+required.
+
+| Runtime | This template | Context contract |
+|---------|---------------|------------------|
+| **gptme** | Native / first-class | Loads `gptme.toml`, runs `context_cmd`, and matches lessons automatically |
+| **Claude Code** | First-class alternative with an autonomous launcher | Uses `AGENTS.md`/`CLAUDE.md`; the launcher builds a shared system prompt |
+| **Codex** | Manual workspace compatibility; no launcher | Reads `AGENTS.md`; run `scripts/context.sh` and load bootstrap files manually |
+| **Grok Build** | Not wired; external adapter required | An adapter must inject the workspace prompt/context and preserve run state |
+| **Pi** | Not wired; experimental adapter required | Do not treat it as supported until its context, auth, and session lifecycle are smoke-tested |
+
+The compatibility level is the important claim. “Can read the repository” is
+not the same as “ships a reliable autonomous adapter.”
+
+### Shipped Alternative: Claude Code
 
 The template also supports Claude Code as an alternative backend:
 
@@ -155,7 +186,8 @@ To customize the autonomous behavior, edit the run script for your backend:
 - Two-queue system (manual + generated priorities)
 - Safety guardrails (GREEN/YELLOW/RED operation classification)
 - Session documentation and state management
-- **Multi-backend**: Supports both gptme and Claude Code backends
+- **Two shipped autonomous launchers**: gptme and Claude Code; other harnesses
+  need an adapter that preserves the same workspace contract
 
 ### Minimal Headless Alternative
 

--- a/scripts/runs/autonomous/README.md
+++ b/scripts/runs/autonomous/README.md
@@ -10,16 +10,21 @@ Autonomous runs enable your agent to work independently without human interventi
 - Safety guardrails and operational guidelines
 - Session documentation and state management
 
-## Backends
+## Shipped Autonomous Backends
 
-Two backends are supported:
+This template ships two autonomous launchers:
 
 | Backend | Script | Best For |
 |---------|--------|----------|
 | **gptme** | `autonomous-run.sh` | gptme-native agents, local models |
 | **Claude Code** | `autonomous-run-cc.sh` | Claude Max subscription, Claude-native tooling |
 
-Both backends use the same identity files (from `gptme.toml`) and follow the same CASCADE workflow.
+Both launchers use the same identity files (from `gptme.toml`) and follow the
+same CASCADE workflow. The workspace itself can be opened by other runtimes,
+but manual compatibility is not the same as a supported autonomous launcher.
+See the root README's [runtime compatibility
+matrix](../../../README.md#one-agent-multiple-runtimes) for Codex, Grok Build,
+and Pi status.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- center the template's runtime story on "your agent is the workspace, not the harness"
- separate workspace, harness, model/provider, and access/billing layers
- publish an honest support matrix for gptme, Claude Code, Codex, Grok Build, and Pi
- clarify bootstrap expectations in `AGENTS.md` and the autonomous-run docs

This deliberately does not imply a full Cartesian product or call manual
workspace compatibility a supported autonomous adapter.

Addresses #91.

## Validation

- `prek run --files README.md AGENTS.md scripts/runs/autonomous/README.md`
- markdown link, template-name, structure, and code-block hooks pass
