### PR TITLE
fix(validation): move root allowlist under .github

### DIFF
--- a/.github/root-structure-allowlist.yaml
+++ b/.github/root-structure-allowlist.yaml
@@ -11,7 +11,6 @@ allowed_entries:
   - .gitmodules
   - .pre-commit-config.yaml
   - gptme.toml
-  - root-structure-allowlist.yaml
 
   # Identity and documentation (auto-included via gptme.toml)
   - ABOUT.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: 13d63e63b35705bc16646ed4b0964dcfa176bc43  # gptme/gptme-contrib#1520
     hooks:
       - id: validate-root-structure
+        args: [--config, .github/root-structure-allowlist.yaml]
   - repo: local
     hooks:
       - id: check-names

--- a/scripts/fork.sh
+++ b/scripts/fork.sh
@@ -213,7 +213,7 @@ copy_file TASKS.md
 copy_file WORKFLOW.md
 copy_file gptme.toml
 copy_file .pre-commit-config.yaml
-copy_file root-structure-allowlist.yaml
+copy_file .github/root-structure-allowlist.yaml
 copy_file .gitignore
 copy_file .gitmodules
 


### PR DESCRIPTION
Follow-up to Erik's comment on gptme/gptme-agent-template#88.

Moves the validator's policy file out of the repository root and into `.github/`, then passes that path explicitly to the shared hook. The fork path copies the file at its new location so generated workspaces retain the guard without adding a root-level policy file.

Verified:
- `pre-commit run validate-root-structure --all-files`
- `pre-commit run check-yaml --files .github/root-structure-allowlist.yaml .pre-commit-config.yaml`
- `pre-commit run shellcheck --files scripts/fork.sh`
- minimal fork contains `.github/root-structure-allowlist.yaml`, not a root-level allowlist; its validator passes

This deliberately changes only the template. The same root-level file exists in gptme and gptme-cloud; those should follow the same convention in separate, repo-scoped changes.
